### PR TITLE
feat: add integration tests and fix adapter text extraction

### DIFF
--- a/despii/adapters/base.py
+++ b/despii/adapters/base.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -60,7 +59,6 @@ class LLMRegistry:
         return adapter
 
     @classmethod
-    @functools.cache
     def detect(cls, model: Any) -> str | None:  # noqa: ANN401
         """Detect framework from model's module name.
 

--- a/despii/adapters/dspy.py
+++ b/despii/adapters/dspy.py
@@ -24,6 +24,13 @@ class DSPyAdapter(LLMAdapter):
                 f"DSPy model {type(self.model)} does not implement '__call__' or 'generate_text'."
             )
 
-        text = raw if isinstance(raw, str) else getattr(raw, "text", str(raw))
+        # Extract text - DSPy returns a list of strings, so get the first element
+        if isinstance(raw, str):
+            text = raw
+        elif isinstance(raw, list) and len(raw) > 0:
+            text = raw[0] if isinstance(raw[0], str) else getattr(raw[0], "text", str(raw[0]))
+        else:
+            text = getattr(raw, "text", str(raw))
+
         logger.debug("DSPyAdapter response generated (length: %d chars)", len(text))
         return LLMResponse(text=text, raw=raw, framework="dspy", model_name=getattr(self.model, "model", None))

--- a/despii/detectors/llm.py
+++ b/despii/detectors/llm.py
@@ -151,9 +151,12 @@ class PiiLLM:
         if self.adapter:
             logger.debug("Starting LLM PII detection (text length: %d chars)", len(text))
             prompt = _PROMPT.replace("{{INPUT_TEXT}}", text)
-            resp = self.adapter.generate(prompt, **kwargs).raw[0]
+            resp = self.adapter.generate(prompt, **kwargs).text
+
+            logger.debug("Raw LLM response (first 200 chars): %s...", resp[:200])
 
             cleaned_resp = _clean_llm_response(resp)
+            logger.debug("Cleaned response (first 200 chars): %s...", cleaned_resp[:200])
 
             try:
                 parsed_json = json.loads(cleaned_resp)
@@ -164,9 +167,9 @@ class PiiLLM:
                     logger.debug("Detected PII labels: %s", labels)
                 return pii_items
             except (json.JSONDecodeError, ValueError, TypeError) as e:
-                logger.debug(
+                logger.warning(
                     "Failed to parse LLM response as JSON. Response: %r. Error: %s",
-                    resp,
+                    resp[:500],
                     e,
                 )
                 return []

--- a/justfile
+++ b/justfile
@@ -5,4 +5,10 @@ lint:
   poetry run pre-commit run --all-files
 
 test: install
+  poetry run pytest tests/unit
+
+test-integration: install
+  poetry run pytest tests/integration -m integration -n 0
+
+test-all: install
   poetry run pytest .

--- a/poetry.lock
+++ b/poetry.lock
@@ -1601,6 +1601,22 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
+name = "langchain-ollama"
+version = "0.2.3"
+description = "An integration package connecting Ollama and LangChain"
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["dev"]
+files = [
+    {file = "langchain_ollama-0.2.3-py3-none-any.whl", hash = "sha256:c47700ca68b013358b1e954493ecafb3bd10fa2cda71a9f15ba7897587a9aab2"},
+    {file = "langchain_ollama-0.2.3.tar.gz", hash = "sha256:d13fe8735176b652ca6e6656d7902c1265e8c0601097569f7c95433f3d034b38"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.3.33,<0.4.0"
+ollama = ">=0.4.4,<1"
+
+[[package]]
 name = "langchain-text-splitters"
 version = "0.3.11"
 description = "LangChain text splitting utilities"
@@ -2245,6 +2261,22 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
 ]
+
+[[package]]
+name = "ollama"
+version = "0.6.0"
+description = "The official Python client for Ollama."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "ollama-0.6.0-py3-none-any.whl", hash = "sha256:534511b3ccea2dff419ae06c3b58d7f217c55be7897c8ce5868dfb6b219cf7a0"},
+    {file = "ollama-0.6.0.tar.gz", hash = "sha256:da2b2d846b5944cfbcee1ca1e6ee0585f6c9d45a2fe9467cbcd096a37383da2f"},
+]
+
+[package.dependencies]
+httpx = ">=0.27"
+pydantic = ">=2.9"
 
 [[package]]
 name = "openai"
@@ -4523,4 +4555,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.14"
-content-hash = "bbcc9079469bdb52000ecee7cbe1f0156c5122d81fa06b6be3ebe250ebff3f3d"
+content-hash = "eb2d8b07a54d721f67958ab702f48ba5e148ee0f2228decf744fdbf5a9a6f2dd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,16 @@ pytest-timeout = "^2.4.0"
 dspy = "^3.0.3"
 langchain = "^0.3.27"
 langgraph = "^0.6.10"
+langchain-ollama = "^0.2.0"
 
 [tool.pytest.ini_options]
 addopts = "-n auto --timeout=300 --cov"
 log_cli_level = "INFO"
 testpaths = ["tests"]
+markers = [
+  "integration: marks tests as integration tests (require external services like Ollama)",
+  "unit: marks tests as unit tests (fast, no external dependencies)",
+]
 filterwarnings = [
   "ignore::DeprecationWarning",
   "ignore::PendingDeprecationWarning",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,136 @@
+# Integration Tests
+
+Integration tests for despii that verify functionality with real LLM models and services.
+
+## Requirements
+
+### Ollama Setup
+
+Integration tests require [Ollama](https://ollama.ai/) to be installed and running locally with the `llama3:8b` model.
+
+**Installation:**
+
+```bash
+# macOS/Linux
+curl -fsSL https://ollama.ai/install.sh | sh
+
+# Or via Homebrew on macOS
+brew install ollama
+```
+
+**Setup llama3:8b model:**
+
+```bash
+ollama pull llama3:8b
+```
+
+**Start Ollama server:**
+
+```bash
+ollama serve
+```
+
+The server should be running at `http://localhost:11434` (default).
+
+## Running Integration Tests
+
+### Run Only Integration Tests
+
+```bash
+just test-integration
+```
+
+Or directly with pytest:
+
+```bash
+poetry run pytest tests/integration -m integration
+```
+
+### Run All Tests (Unit + Integration)
+
+```bash
+just test-all
+```
+
+### Run Specific Integration Test Files
+
+```bash
+# Test DSPy adapter
+poetry run pytest tests/integration/adapters/test_dspy_integration.py -m integration
+
+# Test LangChain adapter
+poetry run pytest tests/integration/adapters/test_langchain_integration.py -m integration
+
+# Test LangGraph adapter
+poetry run pytest tests/integration/adapters/test_langgraph_integration.py -m integration
+
+# Test full LLM detector flow
+poetry run pytest tests/integration/detectors/test_llm_integration.py -m integration
+```
+
+## Test Coverage
+
+### Adapter Tests
+
+- **DSPy Integration** (`test_dspy_integration.py`):
+  - Verify DSPy adapter works with real Ollama model
+  - Test response generation and parsing
+  - Test PII detection prompts
+  - Verify raw response preservation
+
+- **LangChain Integration** (`test_langchain_integration.py`):
+  - Verify LangChain adapter works with ChatOllama
+  - Test response generation
+  - Test PII detection prompts
+  - Test kwargs passing (temperature, max_tokens, etc.)
+
+- **LangGraph Integration** (`test_langgraph_integration.py`):
+  - Verify LangGraph adapter works with ChatOllama
+  - Test invoke method functionality
+  - Test PII detection prompts
+
+### Detector Tests
+
+- **LLM Detector Flow** (`test_llm_integration.py`):
+  - Test PiiLLM with each adapter (DSPy, LangChain, LangGraph)
+  - Verify framework detection via settings configuration
+  - Test full `llm_pass()` flow with RedactionContext
+  - Test with various PII types and edge cases
+  - Verify multiple sequential calls work correctly
+
+## Skipping Tests
+
+Integration tests automatically skip if Ollama is not available:
+
+```python
+pytest.skip("Ollama with llama3:8b model not available")
+```
+
+No manual configuration needed - tests will gracefully skip if requirements aren't met.
+
+## Notes
+
+- Integration tests are slower than unit tests (require actual LLM calls)
+- Tests use `timeout=300` seconds by default
+- Ollama responses may vary, so tests focus on structure rather than exact content
+- Tests verify the integration works without asserting specific PII detection accuracy
+  (LLM behavior can be non-deterministic)
+
+## Troubleshooting
+
+**Tests are skipped:**
+
+- Ensure Ollama is running: `ollama serve`
+- Verify llama3:8b is installed: `ollama list`
+- Check Ollama is accessible: `curl http://localhost:11434`
+
+**Tests timeout:**
+
+- First run may be slow (model loading)
+- Check Ollama server logs for errors
+- Increase timeout if needed for slower systems
+
+**Import errors:**
+
+- Run `poetry install` to install all dependencies
+- Ensure dspy, langchain, and langgraph are installed

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for despii."""

--- a/tests/integration/adapters/__init__.py
+++ b/tests/integration/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for adapters."""

--- a/tests/integration/adapters/test_dspy_integration.py
+++ b/tests/integration/adapters/test_dspy_integration.py
@@ -1,0 +1,92 @@
+"""Integration tests for DSPy adapter with real models."""
+
+import pytest
+
+pytest.importorskip("dspy")
+
+import dspy  # noqa: E402
+
+from despii.adapters.dspy import DSPyAdapter  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class TestDSPyAdapterIntegration:
+    """Integration tests for DSPy adapter with Ollama."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create DSPy LM with Ollama.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: DSPy LM instance
+        """
+        return dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create DSPyAdapter with Ollama model.
+
+        :param ollama_model: DSPy LM instance
+        :return: DSPyAdapter instance
+        """
+        return DSPyAdapter(ollama_model)
+
+    def test_dspy_adapter_can_generate_response(self, adapter, test_prompt):
+        """Test that DSPy adapter can generate a response with real model.
+
+        :param adapter: DSPyAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(test_prompt)
+
+        assert response is not None
+        assert response.text
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+        assert response.framework == "dspy"
+
+    def test_dspy_adapter_response_contains_expected_content(self, adapter):
+        """Test that DSPy adapter returns relevant responses.
+
+        :param adapter: DSPyAdapter instance
+        """
+        prompt = "What is 2+2? Answer with just the number."
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        # Should contain "4" somewhere in response
+        assert "4" in response.text
+
+    def test_dspy_adapter_handles_pii_detection_prompt(self, adapter):
+        """Test DSPy adapter with a PII detection prompt.
+
+        :param adapter: DSPyAdapter instance
+        """
+        prompt = """Identify any personally identifiable information (PII) in this text:
+"My name is Alice Johnson and my email is alice@example.com"
+
+Return a JSON array with objects containing 'pii_str' and 'label' fields."""
+
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        assert response.text
+        # Response should mention some PII-related content
+        assert any(
+            word in response.text.lower() for word in ["alice", "email", "pii", "personal", "information", "name"]
+        )
+
+    def test_dspy_adapter_preserves_raw_response(self, adapter, test_prompt):
+        """Test that raw response is preserved in LLMResponse.
+
+        :param adapter: DSPyAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(prompt=test_prompt)
+
+        assert response.raw is not None
+        # Raw response should be a list for DSPy
+        assert isinstance(response.raw, list)
+        assert len(response.raw) > 0

--- a/tests/integration/adapters/test_langchain_integration.py
+++ b/tests/integration/adapters/test_langchain_integration.py
@@ -1,0 +1,89 @@
+"""Integration tests for LangChain adapter with real models."""
+
+import pytest
+
+pytest.importorskip("langchain")
+
+from langchain_ollama import ChatOllama  # noqa: E402
+
+from despii.adapters.langchain import LangChainAdapter  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class TestLangChainAdapterIntegration:
+    """Integration tests for LangChain adapter with Ollama."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create LangChain ChatOllama model.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: ChatOllama instance
+        """
+        return ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create LangChainAdapter with Ollama model.
+
+        :param ollama_model: ChatOllama instance
+        :return: LangChainAdapter instance
+        """
+        return LangChainAdapter(ollama_model)
+
+    def test_langchain_adapter_can_generate_response(self, adapter, test_prompt):
+        """Test that LangChain adapter can generate a response with real model.
+
+        :param adapter: LangChainAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(test_prompt)
+
+        assert response is not None
+        assert response.text
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+        assert response.framework == "langchain"
+
+    def test_langchain_adapter_response_contains_expected_content(self, adapter):
+        """Test that LangChain adapter returns relevant responses.
+
+        :param adapter: LangChainAdapter instance
+        """
+        prompt = "What is 2+2? Answer with just the number."
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        # Should contain "4" somewhere in response
+        assert "4" in response.text
+
+    def test_langchain_adapter_handles_pii_detection_prompt(self, adapter):
+        """Test LangChain adapter with a PII detection prompt.
+
+        :param adapter: LangChainAdapter instance
+        """
+        prompt = """Identify any personally identifiable information (PII) in this text:
+"My name is Bob Wilson and my phone is 555-1234"
+
+Return a JSON array with objects containing 'pii_str' and 'label' fields."""
+
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        assert response.text
+        # Response should mention some PII-related content
+        assert any(word in response.text.lower() for word in ["bob", "phone", "pii", "personal", "information", "name"])
+
+    def test_langchain_adapter_preserves_raw_response(self, adapter, test_prompt):
+        """Test that raw response is preserved in LLMResponse.
+
+        :param adapter: LangChainAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(test_prompt)
+
+        assert response.raw is not None
+        # Raw should have content attribute for LangChain
+        assert hasattr(response.raw, "content") or isinstance(response.raw, str)

--- a/tests/integration/adapters/test_langgraph_integration.py
+++ b/tests/integration/adapters/test_langgraph_integration.py
@@ -1,0 +1,104 @@
+"""Integration tests for LangGraph adapter with real models."""
+
+import pytest
+
+pytest.importorskip("langgraph")
+pytest.importorskip("langchain")
+
+from langchain_ollama import ChatOllama  # noqa: E402
+
+from despii.adapters.langgraph import LangGraphAdapter  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class TestLangGraphAdapterIntegration:
+    """Integration tests for LangGraph adapter with Ollama."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create ChatOllama model for LangGraph.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: ChatOllama instance
+        """
+        return ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create LangGraphAdapter with Ollama model.
+
+        :param ollama_model: ChatOllama instance
+        :return: LangGraphAdapter instance
+        """
+        return LangGraphAdapter(ollama_model)
+
+    def test_langgraph_adapter_can_generate_response(self, adapter, test_prompt):
+        """Test that LangGraph adapter can generate a response with real model.
+
+        :param adapter: LangGraphAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(test_prompt)
+
+        assert response is not None
+        assert response.text
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+        assert response.framework == "langgraph"
+
+    def test_langgraph_adapter_response_contains_expected_content(self, adapter):
+        """Test that LangGraph adapter returns relevant responses.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        prompt = "What is 2+2? Answer with just the number."
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        # Should contain "4" somewhere in response
+        assert "4" in response.text
+
+    def test_langgraph_adapter_handles_pii_detection_prompt(self, adapter):
+        """Test LangGraph adapter with a PII detection prompt.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        prompt = """Identify any personally identifiable information (PII) in this text:
+"My name is Charlie Brown and my SSN is 123-45-6789"
+
+Return a JSON array with objects containing 'pii_str' and 'label' fields."""
+
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        assert response.text
+        # Response should mention some PII-related content
+        assert any(
+            word in response.text.lower() for word in ["charlie", "ssn", "pii", "personal", "information", "name"]
+        )
+
+    def test_langgraph_adapter_preserves_raw_response(self, adapter, test_prompt):
+        """Test that raw response is preserved in LLMResponse.
+
+        :param adapter: LangGraphAdapter instance
+        :param test_prompt: Test prompt fixture
+        """
+        response = adapter.generate(test_prompt)
+
+        assert response.raw is not None
+        # Raw should have content attribute for LangGraph (uses LangChain models)
+        assert hasattr(response.raw, "content") or isinstance(response.raw, str)
+
+    def test_langgraph_adapter_invoke_method(self, adapter):
+        """Test LangGraph adapter uses invoke method correctly.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        prompt = "Say hello briefly"
+        response = adapter.generate(prompt)
+
+        assert response is not None
+        assert response.text
+        assert len(response.text) > 0

--- a/tests/integration/adapters/test_text_extraction.py
+++ b/tests/integration/adapters/test_text_extraction.py
@@ -1,0 +1,185 @@
+"""Integration tests to verify proper text extraction from LLM responses across all adapters."""
+
+import pytest
+
+pytest.importorskip("dspy")
+pytest.importorskip("langchain")
+pytest.importorskip("langgraph")
+
+import dspy  # noqa: E402
+from langchain_ollama import ChatOllama  # noqa: E402
+
+from despii.adapters.dspy import DSPyAdapter  # noqa: E402
+from despii.adapters.langchain import LangChainAdapter  # noqa: E402
+from despii.adapters.langgraph import LangGraphAdapter  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class TestTextExtractionDSPy:
+    """Integration tests for DSPy adapter text extraction."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create DSPy LM with Ollama.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: DSPy LM instance
+        """
+        return dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create DSPyAdapter with Ollama model.
+
+        :param ollama_model: DSPy LM instance
+        :return: DSPyAdapter instance
+        """
+        return DSPyAdapter(ollama_model)
+
+    def test_text_field_is_string(self, adapter):
+        """Test that DSPy adapter returns text field as string, not list.
+
+        :param adapter: DSPyAdapter instance
+        """
+        response = adapter.generate("Say hello")
+
+        # Text field must be a string, not a list
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+        # Should not have Python list representation characters
+        assert not response.text.startswith("[")
+        assert not response.text.endswith("]")
+
+    def test_text_contains_actual_response(self, adapter):
+        """Test that text field contains actual LLM response content.
+
+        :param adapter: DSPyAdapter instance
+        """
+        response = adapter.generate("What is 2+2? Answer with just the number.")
+
+        assert isinstance(response.text, str)
+        # Should contain the answer
+        assert "4" in response.text
+        # Should not be a Python representation
+        assert "['4']" not in response.text
+
+    def test_json_response_properly_extracted(self, adapter):
+        """Test that JSON responses are properly extracted as strings.
+
+        :param adapter: DSPyAdapter instance
+        """
+        prompt = 'Return this JSON: [{"key": "value"}]'
+        response = adapter.generate(prompt)
+
+        assert isinstance(response.text, str)
+        # Should be able to parse as JSON if LLM returns JSON
+        # (might have markdown wrapping, but should be string)
+        assert not response.text.startswith("['")
+
+
+class TestTextExtractionLangChain:
+    """Integration tests for LangChain adapter text extraction."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create LangChain ChatOllama model.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: ChatOllama instance
+        """
+        return ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create LangChainAdapter with Ollama model.
+
+        :param ollama_model: ChatOllama instance
+        :return: LangChainAdapter instance
+        """
+        return LangChainAdapter(ollama_model)
+
+    def test_text_field_is_string(self, adapter):
+        """Test that LangChain adapter returns text field as string.
+
+        :param adapter: LangChainAdapter instance
+        """
+        response = adapter.generate("Say hello")
+
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+
+    def test_text_contains_actual_response(self, adapter):
+        """Test that text field contains actual LLM response content.
+
+        :param adapter: LangChainAdapter instance
+        """
+        response = adapter.generate("What is 2+2? Answer with just the number.")
+
+        assert isinstance(response.text, str)
+        assert "4" in response.text
+
+    def test_json_response_properly_extracted(self, adapter):
+        """Test that JSON responses are properly extracted as strings.
+
+        :param adapter: LangChainAdapter instance
+        """
+        prompt = 'Return this JSON: [{"key": "value"}]'
+        response = adapter.generate(prompt)
+
+        assert isinstance(response.text, str)
+
+
+class TestTextExtractionLangGraph:
+    """Integration tests for LangGraph adapter text extraction."""
+
+    @pytest.fixture
+    def ollama_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Create ChatOllama model for LangGraph.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        :return: ChatOllama instance
+        """
+        return ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+
+    @pytest.fixture
+    def adapter(self, ollama_model):
+        """Create LangGraphAdapter with Ollama model.
+
+        :param ollama_model: ChatOllama instance
+        :return: LangGraphAdapter instance
+        """
+        return LangGraphAdapter(ollama_model)
+
+    def test_text_field_is_string(self, adapter):
+        """Test that LangGraph adapter returns text field as string.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        response = adapter.generate("Say hello")
+
+        assert isinstance(response.text, str)
+        assert len(response.text) > 0
+
+    def test_text_contains_actual_response(self, adapter):
+        """Test that text field contains actual LLM response content.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        response = adapter.generate("What is 2+2? Answer with just the number.")
+
+        assert isinstance(response.text, str)
+        assert "4" in response.text
+
+    def test_json_response_properly_extracted(self, adapter):
+        """Test that JSON responses are properly extracted as strings.
+
+        :param adapter: LangGraphAdapter instance
+        """
+        prompt = 'Return this JSON: [{"key": "value"}]'
+        response = adapter.generate(prompt)
+
+        assert isinstance(response.text, str)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,78 @@
+"""Pytest configuration for integration tests."""
+
+import subprocess
+
+import pytest
+
+
+def is_ollama_available() -> bool:
+    """Check if Ollama is running and llama3 model is available.
+
+    :return: True if Ollama is available with llama3 model
+    """
+    try:
+        result = subprocess.run(
+            ["ollama", "list"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0 and "llama3" in result.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+@pytest.fixture(scope="session")
+def ollama_available() -> bool:
+    """Check if Ollama is available for integration tests.
+
+    :return: True if Ollama is available
+    """
+    return is_ollama_available()
+
+
+@pytest.fixture(scope="session")
+def skip_if_no_ollama(ollama_available: bool) -> None:  # noqa: PT004
+    """Skip test if Ollama is not available.
+
+    :param ollama_available: Whether Ollama is available
+    """
+    if not ollama_available:
+        pytest.skip("Ollama with llama3 model not available")
+
+
+@pytest.fixture(scope="session")
+def ollama_model_name() -> str:
+    """Get the Ollama model name to use for tests.
+
+    :return: Model name (llama3.1:8b or llama3:8b)
+    """
+    result = subprocess.run(
+        ["ollama", "list"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+    if "llama3.1:8b" in result.stdout:
+        return "llama3.1:8b"
+    return "llama3:8b"
+
+
+@pytest.fixture
+def test_prompt() -> str:
+    """Provide a simple test prompt for integration tests.
+
+    :return: Test prompt string
+    """
+    return "Say 'Hello, World!' and nothing else."
+
+
+@pytest.fixture
+def pii_test_text() -> str:
+    """Provide test text containing PII for detector tests.
+
+    :return: Text with PII for testing
+    """
+    return "My name is John Smith and my email is john.smith@example.com. I live in New York."

--- a/tests/integration/detectors/__init__.py
+++ b/tests/integration/detectors/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for detectors."""

--- a/tests/integration/detectors/test_llm_integration.py
+++ b/tests/integration/detectors/test_llm_integration.py
@@ -1,0 +1,219 @@
+"""Integration tests for LLM detector with real models and full flow."""
+
+import pytest
+
+pytest.importorskip("dspy")
+pytest.importorskip("langchain")
+pytest.importorskip("langgraph")
+
+import dspy  # noqa: E402
+from langchain_ollama import ChatOllama  # noqa: E402
+
+from despii.core import RedactionContext  # noqa: E402
+from despii.detectors.llm import PiiLLM, llm_pass  # noqa: E402
+from despii.settings import settings  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+
+class TestLLMDetectorIntegration:
+    """Integration tests for LLM detector with real models."""
+
+    def test_llm_detector_with_dspy_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test LLM detector with DSPy model configured via settings.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        # Configure DSPy model via settings
+        model = dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+        settings.configure(local_lm=model)
+
+        # Create PiiLLM instance
+        detector = PiiLLM()
+
+        # Verify framework detection
+        assert detector.framework == "dspy"
+        assert detector.adapter is not None
+
+        # Test PII detection
+        text = "My name is Alice and my email is alice@test.com"
+        results = detector.generate(text)
+
+        # Should return a list of PIIInfo objects
+        assert isinstance(results, list)
+        # May or may not detect PII depending on model, but should not crash
+        for item in results:
+            assert hasattr(item, "pii_str")
+            assert hasattr(item, "label")
+
+    def test_llm_detector_with_langchain_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test LLM detector with LangChain model configured via settings.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        # Configure LangChain model via settings
+        model = ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+        settings.configure(local_lm=model)
+
+        # Create PiiLLM instance
+        detector = PiiLLM()
+
+        # Verify framework detection
+        assert detector.framework == "langchain"
+        assert detector.adapter is not None
+
+        # Test PII detection
+        text = "My name is Bob and my phone is 555-0123"
+        results = detector.generate(text)
+
+        # Should return a list
+        assert isinstance(results, list)
+        for item in results:
+            assert hasattr(item, "pii_str")
+            assert hasattr(item, "label")
+
+    def test_llm_detector_with_langgraph_model(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test LLM detector with LangGraph model configured via settings.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        # Configure LangGraph model (uses LangChain ChatOllama) via settings
+        model = ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+        settings.configure(local_lm=model)
+
+        # Create PiiLLM instance
+        detector = PiiLLM()
+
+        # Verify framework detection (should detect as langchain)
+        assert detector.framework in {"langchain", "langgraph"}
+        assert detector.adapter is not None
+
+        # Test PII detection
+        text = "Contact Charlie at charlie@example.org"
+        results = detector.generate(text)
+
+        # Should return a list
+        assert isinstance(results, list)
+        for item in results:
+            assert hasattr(item, "pii_str")
+            assert hasattr(item, "label")
+
+    def test_llm_pass_full_flow_with_dspy(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test full llm_pass flow with DSPy model.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        # Configure model
+        model = dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+        settings.configure(local_lm=model)
+
+        # Create redaction context
+        text = "My name is John Doe and my email is john.doe@company.com. I live at 123 Main St."
+        ctx = RedactionContext(text)
+
+        # Run LLM pass
+        result_ctx = llm_pass(ctx)
+
+        # Should return a RedactionContext
+        assert isinstance(result_ctx, RedactionContext)
+        # Redacted text may differ from original if PII was detected
+        assert isinstance(result_ctx.text, str)
+        # May have redactions depending on model performance
+        # Just verify it doesn't crash and returns valid structure
+
+    def test_llm_pass_full_flow_with_langchain(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test full llm_pass flow with LangChain model.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        # Configure model
+        model = ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+        settings.configure(local_lm=model)
+
+        # Create redaction context
+        text = "Call me at 555-1234 or email jane@example.com"
+        ctx = RedactionContext(text)
+
+        # Run LLM pass
+        result_ctx = llm_pass(ctx)
+
+        # Should return a RedactionContext
+        assert isinstance(result_ctx, RedactionContext)
+        # Redacted text may differ from original if PII was detected
+        assert isinstance(result_ctx.text, str)
+
+    def test_llm_detector_handles_no_pii_text(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test LLM detector with text containing no PII.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        model = dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+        settings.configure(local_lm=model)
+
+        detector = PiiLLM()
+        text = "The weather is nice today. It is sunny and warm."
+        results = detector.generate(text)
+
+        # Should return a list (may be empty or have false positives)
+        assert isinstance(results, list)
+
+    def test_llm_detector_with_multiple_pii_types(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test LLM detector with text containing multiple PII types.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        model = ChatOllama(model=ollama_model_name, base_url="http://localhost:11434")
+        settings.configure(local_lm=model)
+
+        detector = PiiLLM()
+        text = """
+        Name: Alice Johnson
+        Email: alice.johnson@company.com
+        Phone: (555) 123-4567
+        SSN: 123-45-6789
+        Address: 456 Oak Avenue, Springfield
+        """
+        results = detector.generate(text)
+
+        # Should return a list of detected PII
+        assert isinstance(results, list)
+        # With multiple clear PII examples, should detect at least something
+        # (though we can't guarantee exact detection with LLMs)
+        for item in results:
+            assert hasattr(item, "pii_str")
+            assert hasattr(item, "label")
+            assert isinstance(item.pii_str, str)
+            assert isinstance(item.label, str)
+
+    def test_llm_detector_repeated_calls_different_inputs(self, skip_if_no_ollama, ollama_model_name):  # noqa: ARG002
+        """Test that LLM detector handles multiple calls with different inputs correctly.
+
+        :param skip_if_no_ollama: Fixture to skip if Ollama not available
+        :param ollama_model_name: Name of Ollama model to use
+        """
+        model = dspy.LM(f"ollama_chat/{ollama_model_name}", api_base="http://localhost:11434", api_key="")
+        settings.configure(local_lm=model)
+
+        detector = PiiLLM()
+
+        # First call
+        results1 = detector.generate("My name is Alice")
+        assert isinstance(results1, list)
+
+        # Second call with different text
+        results2 = detector.generate("Contact Bob at bob@test.com")
+        assert isinstance(results2, list)
+
+        # Third call
+        results3 = detector.generate("The quick brown fox")
+        assert isinstance(results3, list)
+
+        # All should be independent
+        # (we can't assert exact results, but they should all complete)

--- a/tests/unit/detectors/test_detectors_llm.py
+++ b/tests/unit/detectors/test_detectors_llm.py
@@ -149,7 +149,7 @@ class TestPiiLLM:
         # Setup adapter mock
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ['[{"pii_str": "John Doe", "label": "Name"}]']
+        mock_response.text = '[{"pii_str": "John Doe", "label": "Name"}]'
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -185,7 +185,7 @@ class TestPiiLLM:
 
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ["[]"]
+        mock_response.text = "[]"
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -206,9 +206,9 @@ class TestPiiLLM:
 
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = [
+        mock_response.text = (
             '[{"pii_str": "John Doe", "label": "Name"}, {"pii_str": "john@example.com", "label": "Email"}]'
-        ]
+        )
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -233,7 +233,7 @@ class TestPiiLLM:
 
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ["[]"]
+        mock_response.text = "[]"
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -257,7 +257,7 @@ class TestPiiLLM:
 
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ["[]"]
+        mock_response.text = "[]"
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -289,7 +289,7 @@ class TestPiiLLM:
 
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ["[]"]
+        mock_response.text = "[]"
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -349,7 +349,7 @@ class TestPiiLLM:
         # Mock adapter that returns invalid JSON
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ["This is not valid JSON"]
+        mock_response.text = "This is not valid JSON"
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -362,10 +362,10 @@ class TestPiiLLM:
         # Should return empty list instead of raising
         assert result == []
 
-        # Should log debug message about failed JSON parsing
-        debug_calls = [call.args for call in mock_logger.debug.call_args_list]
+        # Should log warning message about failed JSON parsing
+        warning_calls = [call.args for call in mock_logger.warning.call_args_list]
         failed_parse_calls = [
-            call for call in debug_calls if "Failed to parse LLM response as JSON" in call[0]
+            call for call in warning_calls if "Failed to parse LLM response as JSON" in call[0]
         ]
         assert len(failed_parse_calls) == 1
         assert "This is not valid JSON" in str(failed_parse_calls[0][1])
@@ -380,7 +380,7 @@ class TestPiiLLM:
         # Mock adapter that returns JSON in markdown
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ['```json\n[{"pii_str": "John", "label": "Name"}]\n```']
+        mock_response.text = '```json\n[{"pii_str": "John", "label": "Name"}]\n```'
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -406,7 +406,7 @@ class TestPiiLLM:
         # Mock adapter that returns incomplete JSON
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ['[{"pii_str": "John", "label": "Name"']  # Missing closing brackets
+        mock_response.text = '[{"pii_str": "John", "label": "Name"'  # Missing closing brackets
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -419,10 +419,10 @@ class TestPiiLLM:
         # Should return empty list instead of raising
         assert result == []
 
-        # Should log debug message about failed JSON parsing
-        debug_calls = [call.args for call in mock_logger.debug.call_args_list]
+        # Should log warning message about failed JSON parsing
+        warning_calls = [call.args for call in mock_logger.warning.call_args_list]
         failed_parse_calls = [
-            call for call in debug_calls if "Failed to parse LLM response as JSON" in call[0]
+            call for call in warning_calls if "Failed to parse LLM response as JSON" in call[0]
         ]
         assert len(failed_parse_calls) == 1
 
@@ -437,7 +437,7 @@ class TestPiiLLM:
         # Mock adapter that returns JSON with explanatory text
         mock_adapter = Mock(spec=LLMAdapter)
         mock_response = Mock(spec=LLMResponse)
-        mock_response.raw = ['Here is the output: [{"pii_str": "John", "label": "Name"}]']
+        mock_response.text = 'Here is the output: [{"pii_str": "John", "label": "Name"}]'
         mock_adapter.generate.return_value = mock_response
 
         mock_registry.detect.return_value = "dspy"
@@ -450,10 +450,10 @@ class TestPiiLLM:
         # Should return empty list instead of raising
         assert result == []
 
-        # Should log debug message about failed JSON parsing
-        debug_calls = [call.args for call in mock_logger.debug.call_args_list]
+        # Should log warning message about failed JSON parsing
+        warning_calls = [call.args for call in mock_logger.warning.call_args_list]
         failed_parse_calls = [
-            call for call in debug_calls if "Failed to parse LLM response as JSON" in call[0]
+            call for call in warning_calls if "Failed to parse LLM response as JSON" in call[0]
         ]
         assert len(failed_parse_calls) == 1
 


### PR DESCRIPTION
## Overview

Adds comprehensive integration test suite for LLM adapters and detector with Ollama, and fixes critical text extraction bug in DSPy adapter that was preventing PII detection.

## Problem

The DSPy adapter was incorrectly handling response text extraction. DSPy's `LM()` returns responses as a list of strings `['text']`, but the adapter was converting this to a string representation via `str(raw)`, resulting in `"['text']"` instead of `"text"`. This caused JSON parsing failures in the LLM detector, preventing PII detection when using DSPy.

Additionally, there were no integration tests to verify that adapters work correctly with real LLM models end-to-end.

## Changes

### Integration Test Infrastructure
- Added pytest markers for `integration` and `unit` test separation
- Created integration test fixtures for Ollama detection and auto-skip when unavailable
- Added `test-integration` and `test-all` justfile targets
- Integration tests run sequentially (`-n 0`) to avoid race conditions with Ollama
- Auto-detect llama3.1:8b or llama3:8b model availability
- Added langchain-ollama dev dependency

### Integration Tests (30 new tests)
- Adapter integration tests for DSPy, LangChain, and LangGraph with Ollama
- Text extraction verification tests for all adapters
- Full end-to-end LLM detector tests with real model inference
- Tests for multiple PII types, repeated calls, and edge cases

### Adapter Fixes
- Fixed DSPy adapter to properly extract text from list responses
- Normalized text extraction across all adapters via `LLMResponse.text`
- Removed `@functools.cache` from `LLMRegistry.detect()` (caused TypeError with unhashable models)

### Detector Improvements
- Changed llm.py to use normalized `LLMResponse.text` field
- Added debug logging for raw and cleaned LLM responses (truncated)
- Upgraded JSON parse failure logging from debug to warning level
- Truncate logged responses to 500 chars to prevent log spam

### Unit Test Updates
- Updated assertions to check for warning logs instead of debug logs
- All existing unit tests remain passing